### PR TITLE
fix: don't wrap text too soon in Alert component

### DIFF
--- a/src/assets/css/components/alert.css
+++ b/src/assets/css/components/alert.css
@@ -51,9 +51,6 @@
   margin-right: 1rem;
   margin-inline-end: 1rem; }
 
-.alert__text {
-  flex: 1 1 60ch; }
-
 .alert__icon {
   color: inherit;
   position: relative;

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1359,9 +1359,6 @@ a.c-btn {
   margin-right: 1rem;
   margin-inline-end: 1rem; }
 
-.alert__text {
-  flex: 1 1 60ch; }
-
 .alert__icon {
   color: inherit;
   position: relative;

--- a/src/assets/scss/components/alert.scss
+++ b/src/assets/scss/components/alert.scss
@@ -75,20 +75,12 @@
     margin-inline-end: 1rem;
 }
 
-.alert__text {
-    flex: 1 1 60ch;
-}
-
 .alert__icon {
     color: inherit;
     position: relative;
     margin-right: .75rem;
     margin-inline-end: .75rem;
     margin-top: -4px;
-}
-
-.alert__text {
-
 }
 
 .alert__type {


### PR DESCRIPTION
Fix https://github.com/eslint/play.eslint.org/issues/11

<img width="424" alt="Screenshot 2022-04-09 at 6 35 59 AM" src="https://user-images.githubusercontent.com/46647141/162550532-3afc789c-7659-45a1-b039-2c65808f27ca.png">

After the above length, it will wrap.

<img width="446" alt="Screenshot 2022-04-09 at 6 36 45 AM" src="https://user-images.githubusercontent.com/46647141/162550572-29ba542f-0a1b-42ca-910a-5266de6746a7.png">
