### PR TITLE
fix: improve styles for select component in focus state

### DIFF
--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -26,10 +26,10 @@ const customStyles = {
             borderColor: "var(--color-primary-700)"
         }
     }),
-    option: styles => ({
+    option: (styles, state) => ({
         ...styles,
-        backgroundColor: "var(--body-background-color)",
-        color: "var(--body-text-color)",
+        backgroundColor: state.isFocused ? "var(--color-primary-700)" : "var(--body-background-color)",
+        color: state.isFocused ? "white" : "var(--body-text-color)",
         cursor: "pointer",
         border: "1px solid var(--border-color)",
         margin: "-4px 0 -4px 0",


### PR DESCRIPTION
The select component is accessible via keyboard, but the styles were not changing as per the focus state hence it was not visible that it is responding to a keypress.


https://user-images.githubusercontent.com/46647141/164884324-7de34dbf-6f64-4750-8c80-e7d043d713b5.mov

