### PR TITLE
fix: Ensure Playground works from /play

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,6 +25,13 @@ module.exports = function(eleventyConfig) {
     return {
         passthroughFileCopy: true,
 
+        /*
+         * When deployed, this app is loaded from /play and proxied to
+         * the correct server. To ensure that URLs are correct, we need
+         * to apply a prefix.
+         */
+        pathPrefix: "/play",
+
         markdownTemplateEngine: 'njk',
         dataTemplateEngine: 'njk',
         htmlTemplateEngine: 'njk',

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -98,9 +98,9 @@
             });
         }
     </script>
-    <script src="{{ 'assets/js/themes.js' | url }}"></script>
+    <script src="{{ '/assets/js/themes.js' | url }}"></script>
 
-    <link rel="stylesheet" type="text/css" href="{{ 'assets/css/styles.css' | url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/styles.css' | url }}">
 </head>
 
 <body class="{{ hook }} docs">
@@ -108,11 +108,11 @@
 
     {{ content | safe }}
 
-    <script src="{{ 'assets/js/css-vars-ponyfill@2.js' | url }}"></script>
-    <script src="{{ 'assets/js/focus-visible.js' | url }}"></script>
-    <script src="{{ 'assets/js/select.js' | url }}"></script>
-    <script src="{{ 'assets/js/themes.js' | url }}"></script>
-    <script src="{{ 'assets/js/main.js' | url }}"></script>
+    <script src="{{ '/assets/js/css-vars-ponyfill@2.js' | url }}"></script>
+    <script src="{{ '/assets/js/focus-visible.js' | url }}"></script>
+    <script src="{{ '/assets/js/select.js' | url }}"></script>
+    <script src="{{ '/assets/js/themes.js' | url }}"></script>
+    <script src="{{ '/assets/js/main.js' | url }}"></script>
 </body>
 
 </html>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -4,4 +4,4 @@ title: ESLint Playground
 permalink: /
 ---
 
-<script src="/assets/js/playground.js"></script>
+<script src="{{ '/assets/js/playground.js' | url }}"></script>


### PR DESCRIPTION
The playground should be deployed to /play in production, so this change ensures it will work from that path even in development.