### PR TITLE
fix: fix broken link

### DIFF
--- a/src/playground/components/Footer.js
+++ b/src/playground/components/Footer.js
@@ -7,7 +7,7 @@ export default function Footer() {
         <footer className="footer">
             <SocialIcons/>
             <div className="copyright">
-                &copy; OpenJS Foundation and other contributors, <a href="www.openjsf.org">www.openjsf.org</a>
+                &copy; OpenJS Foundation and other contributors, <a href="https://www.openjsf.org">www.openjsf.org</a>
             </div>
             <ThemeSwitcher/>
         </footer>


### PR DESCRIPTION
#### Description:

Current behavior:
In the footer component, the openjs.org link was broken and redirects to the 404 page.

After change:
Fixed the broken link.