### PR TITLE
fix: dev server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install
 Once you have set up your environment, you can run a copy of the website locally using this command:
 
 ```sh
-npm start
+watch:eleventy
 ```
 
 This will watch for changes to the source code and rebuild the website, which will be hosted at `http://localhost:2024/`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install
 Once you have set up your environment, you can run a copy of the website locally using this command:
 
 ```sh
-watch:eleventy
+npm watch:eleventy
 ```
 
 This will watch for changes to the source code and rebuild the website, which will be hosted at `http://localhost:2024/`.


### PR DESCRIPTION
Seems like `npm start` is not the right command to start the dev server? so fixed it to `npm watch:eleventy`
