### PR TITLE
chore: use addEventListener instead of addListener

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -69,7 +69,7 @@ var getClosest = function (elem, selector) {
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 
@@ -110,7 +110,7 @@ var getClosest = function (elem, selector) {
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 


### PR DESCRIPTION
**Description :**
Use addEventListener() instead of matchMedia().addListener() since matchMedia().addListener() is deprecated.