### PR TITLE
fix: selected rule not clearing issue

### DIFF
--- a/src/playground/components/Configuration.js
+++ b/src/playground/components/Configuration.js
@@ -184,7 +184,13 @@ export default function Configuration({ rulesMeta, eslintVersion, onUpdate, opti
                         styles={customStyles}
                         theme={theme => customTheme(theme)}
                         ref={ruleInputRef}
-                        onChange={selected => setSelectedRule(selected.value)}
+                        onChange={selected => {
+                            if (!selected) {
+                                setSelectedRule(null);
+                            } else {
+                                setSelectedRule(selected.value);
+                            }
+                        }}
                         options={ruleNamesOptions}
                     />
                     <button


### PR DESCRIPTION
Description: 
when clicking clear icon on rule select input not clearing the selected rule and throws error. The fix handles the clearing state of rule select input on onchange event.

Before:


https://user-images.githubusercontent.com/60533560/170544217-a30333f5-2ee6-40a7-a6e2-706f14952323.mp4



After:


https://user-images.githubusercontent.com/60533560/170544240-375792e0-4f5a-4928-b928-fff3249a31f9.mp4

