### PR TITLE
fix: remove colon if no line number in error

### DIFF
--- a/src/playground/components/Alert.js
+++ b/src/playground/components/Alert.js
@@ -30,7 +30,7 @@ export default function Alert({ type, text, message, onFix }) {
                     <span className="visually-hidden">Error</span>
                     <p className="alert__line-number">
                         <span className="line-number">{line}</span>
-                        <span aria-hidden="true">:</span>
+                        {line && column && <span aria-hidden="true">:</span>}
                         <span className="colun-number">{column}</span>
                     </p>
                 </div>


### PR DESCRIPTION
Remove colon if no line number is in error.

Before: 
<img width="550" alt="image" src="https://user-images.githubusercontent.com/42372051/171227439-aca87564-70f5-42ea-b2d4-195fc14c5bbf.png">


After :
<img width="550" alt="image" src="https://user-images.githubusercontent.com/42372051/171227308-272e2e73-e737-43db-96fe-4dbdf89f736b.png">
