### PR TITLE
fix: autocomplete tooltip ui not visible in light mode 

### DIFF
--- a/src/playground/utils/codemirror-theme.js
+++ b/src/playground/utils/codemirror-theme.js
@@ -43,6 +43,13 @@ export const ESLintPlaygroundTheme = EditorView.theme({
     },
     ".cm-gutterElement": {
         color: "var(--body-text-color)"
+    },
+    ".cm-tooltip-autocomplete": {
+        backgroundColor: "var(--color-neutral-800)",
+        color: "#fff"
+    },
+    ".cm-completionIcon": {
+        width: "1.2rem"
     }
 }, { dark: true });
 


### PR DESCRIPTION
Description:
Cmd+Space suggestion in codemirror shows some default js snippets in a modal, the ui was broken in both light & dark mode, due to custom theme provided, so made a fix by adding the respective styles for suggestion modal in codemirror theme.

Before (Light mode)
---
<img width="648" alt="image" src="https://user-images.githubusercontent.com/60533560/172036209-c1ffa580-e674-4c3f-95d5-a6031e1faa8b.png">

Before (Dark mode)
---

<img width="648" alt="image" src="https://user-images.githubusercontent.com/60533560/172036218-12fc9de4-cb94-44d9-843e-183468e912c8.png">

After (Light mode)
---
<img width="648" alt="image" src="https://user-images.githubusercontent.com/60533560/172036251-b0b99b9c-e976-4f1d-8075-c5549d129f02.png">

After (Dark mode)
---
<img width="648" alt="image" src="https://user-images.githubusercontent.com/60533560/172036276-b2fe07b5-b87d-45e0-a241-be9ec96fafc2.png">
