### PR TITLE
chore: show progress while bundling via webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "watch:webpack": "webpack watch --mode=development",
         "build:sass": "sass --style=compressed src/assets/scss:src/assets/css --no-source-map",
         "build:eleventy": "eleventy --quiet",
-        "build:webpack": "webpack --mode=production",
+        "build:webpack": "webpack --mode=production --progress",
         "prestart": "npm run build",
         "start": "node tools/dev-server.js",
         "build": "npm-run-all install:playground build:sass build:eleventy build:webpack images",


### PR DESCRIPTION
Webpack build takes significant time and since we log only errors on the console it's better to show progress to let contributors know the build is in progress.

<img width="539" alt="Screenshot 2022-06-05 at 3 14 48 PM" src="https://user-images.githubusercontent.com/46647141/172044730-cb1ddcdc-3eb2-4b48-ad61-c641d8a6a5e2.png">
