### PR TITLE
fix: avoid theme flash

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -44,13 +44,13 @@
     <link rel="preload" href="{{ '/assets/fonts/SpaceMono-Regular-subset.woff2' | url }}" as="font" type="font/woff2" crossorigin>
 
     <script>
-        (function(){
-            var theme = window.localStorage.getItem("theme");
-            if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                document.documentElement.setAttribute('data-theme', 'dark');
-            }
-            else if (theme) document.documentElement.setAttribute('data-theme', theme);
-        })();
+            (function () {
+                var theme = window.localStorage.getItem("theme");
+                if (theme) document.documentElement.setAttribute('data-theme', theme)
+                else if (window.matchMedia('(prefers-color-scheme: dark)').matches)
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                else document.documentElement.setAttribute('data-theme', 'light');
+            })();
     </script>
 
 

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -1,58 +1,42 @@
 /* theme toggle buttons */
 (function() {
-    var enableToggle = function(btn) {
+    var enableToggle = function (btn) {
         btn.setAttribute("aria-pressed", "true");
     }
-
-    var disableToggle = function(btn) {
+    var disableToggle = function (btn) {
         btn.setAttribute("aria-pressed", "false");
+    }
+    var setTheme = function (theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        window.localStorage.setItem("theme", theme);
     }
 
 
     let theme = window.localStorage.getItem("theme");
-    document.documentElement.setAttribute('data-theme', theme);
-    if (!theme) document.documentElement.setAttribute('data-theme', 'light');
-
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
         var switcher = document.getElementById('js-theme-switcher');
-
-        if(!switcher)
-        return;
-
         switcher.removeAttribute('hidden');
         var light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
-
-        // get any previously-chosen themes
-        var theme = window.localStorage.getItem("theme");
-        if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.documentElement.setAttribute('data-theme', 'dark');
+        if (theme) {
+            if (theme === "light") {
+                enableToggle(light_theme_toggle);
+                disableToggle(dark_theme_toggle);
+            } else if (theme === "dark") {
+                enableToggle(dark_theme_toggle);
+                disableToggle(light_theme_toggle);
+            }
         }
-        else if (theme) document.documentElement.setAttribute('data-theme', theme);
-
-        if (theme == "light") {
-            enableToggle(light_theme_toggle);
-            disableToggle(dark_theme_toggle);
-        } else if (theme == "dark") {
-            enableToggle(dark_theme_toggle);
-            disableToggle(light_theme_toggle);
-        }
-
-        light_theme_toggle.addEventListener("click", function() {
+        light_theme_toggle.addEventListener("click", function () {
             enableToggle(light_theme_toggle);
             theme = this.getAttribute('data-theme');
-            document.documentElement.setAttribute('data-theme', theme);
-            window.localStorage.setItem("theme", theme);
-
+            setTheme(theme);
             disableToggle(dark_theme_toggle);
         }, false);
-
-        dark_theme_toggle.addEventListener("click", function() {
+        dark_theme_toggle.addEventListener("click", function () {
             enableToggle(dark_theme_toggle);
             theme = this.getAttribute('data-theme');
-            document.documentElement.setAttribute('data-theme', theme);
-            window.localStorage.setItem("theme", theme);
-
+            setTheme(theme);
             disableToggle(light_theme_toggle);
         }, false);
     }, false);


### PR DESCRIPTION
**Description:**

Theme flashes when the theme is not set and the prefers-color-scheme is dark. Stopped the theme flashing and removed redundant code.

Before changes:

https://user-images.githubusercontent.com/30730124/172051113-7101ba58-fdba-444b-bd67-a0a4f37b53b8.mov

After changes:

https://user-images.githubusercontent.com/30730124/172051126-cf043c9a-e687-43f5-b31b-38426f4e4f84.mov



