### PR TITLE
chore: remove redundant props

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -149,14 +149,12 @@ const App = () => {
                         <CodeEditor
                             tabIndex="0"
                             codeValue={text}
-                            errors={messages}
                             eslintOptions={options}
                             onUpdate={value => {
                                 setFix(false);
                                 setText(value);
                                 storeState({ newText: value });
                             }}
-                            getIndexFromLoc={sourceCode && sourceCode.getIndexFromLoc.bind(sourceCode)}
                         />
                     </main>
                     <section className="playground__console" aria-labelledby="playground__console-label">

--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -96,7 +96,6 @@ const App = () => {
 
     const { messages, output, fatalMessage, error: crashError } = lint();
     const isInvalidAutofix = fatalMessage && text !== output;
-    const sourceCode = linter.getSourceCode();
 
     const onFix = message => {
         if (message.fix) {


### PR DESCRIPTION
Only  `codeValue`, `onUpdate`, and `eslintOptions` are valid.
https://github.com/eslint/playground/blob/d640299b724d234beae2e9f4950e681d701809d9/src/playground/components/CodeEditor.js#L11