### PR TITLE
fix: Use replaceState on code changes

### DIFF
--- a/src/playground/App.js
+++ b/src/playground/App.js
@@ -103,7 +103,10 @@ const App = () => {
             window.localStorage.setItem("linterDemoState", serializedState);
         }
 
-        window.location.hash = Unicode.encodeToBase64(serializedState);
+        const url = new URL(location);
+
+        url.hash = Unicode.encodeToBase64(serializedState);
+        history.replaceState(null, null, url);
     };
 
     const { messages, output, fatalMessage, error: crashError, validationError } = lint();


### PR DESCRIPTION
This should overwrite the single existing history entry rather than creating a new history entry for each code change.

Fixes #69