### PR TITLE
fix: donate link

### DIFF
--- a/src/_includes/components/navigation.html
+++ b/src/_includes/components/navigation.html
@@ -1,7 +1,7 @@
 <nav class="site-nav" aria-label="Main">
     <div class="flexer">
 
-        <a href="{{ navigation.donate.url }}" class="c-btn c-btn--primary donate-link">{{navigation.donate.text}}</a>
+        <a href="{{ links.donate }}" class="c-btn c-btn--primary donate-link">{{ site.shared.donate }}</a>
         <button class="site-nav-toggle" aria-label="Menu" id="nav-toggle">
             <svg width="20" height="20" viewBox="20 20 60 60">
                 <path id="ham-top"    d="M30,37 L70,37 Z" stroke="currentColor"></path>


### PR DESCRIPTION
**Description:**

 Donate link button is broken. In https://github.com/eslint/playground/pull/64 old donate link was merged. Donate link was updated in the https://github.com/eslint/playground/pull/73. So replaced the old link with the new one.
 
|   Before      | After |
| ----------- | ----------- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/30730124/176952766-74cac54b-f4ec-48c7-b6e1-f11b894df955.png">      |   <img width="400" alt="image" src="https://user-images.githubusercontent.com/30730124/176953087-5e7937e7-1c2c-49ba-a654-9e698d88e712.png">       |


