### PR TITLE
fix: clean ruleName

### DIFF
--- a/src/playground/utils/codemirror-linter-extension.js
+++ b/src/playground/utils/codemirror-linter-extension.js
@@ -273,12 +273,23 @@ function renderDiagnostic(view, diagnostic) {
     const element = document.createElement("div");
     const root = ReactDOM.createRoot(element);
 
+    let ruleName = "";
+
+    if (diagnostic.source === "jshint") {
+
+        // leave ruleName blank
+    } else {
+
+        // remove 'jshint:' in the beginning
+        ruleName = diagnostic.source.replace(/^jshint:/u, "");
+    }
+
     root.render(
         <React.StrictMode>
             <Popup
                 message={diagnostic.message}
                 onFix={diagnostic.actions && (() => diagnostic.actions[0].apply(view, diagnostic.from, diagnostic.to))}
-                ruleName={diagnostic.source.replace("jshint:", "").replace("jshint", "")}
+                ruleName={ruleName}
             />
         </React.StrictMode>
     );

--- a/src/playground/utils/codemirror-linter-extension.js
+++ b/src/playground/utils/codemirror-linter-extension.js
@@ -273,6 +273,8 @@ function renderDiagnostic(view, diagnostic) {
     const element = document.createElement("div");
     const root = ReactDOM.createRoot(element);
 
+    // clean up ruleName first
+    // see https://github.com/codemirror/lang-javascript/blob/main/src/eslint.ts#L51
     let ruleName = "";
 
     if (diagnostic.source === "jshint") {

--- a/src/playground/utils/codemirror-linter-extension.js
+++ b/src/playground/utils/codemirror-linter-extension.js
@@ -274,17 +274,8 @@ function renderDiagnostic(view, diagnostic) {
     const root = ReactDOM.createRoot(element);
 
     // clean up ruleName first
-    // see https://github.com/codemirror/lang-javascript/blob/main/src/eslint.ts#L51
-    let ruleName = "";
-
-    if (diagnostic.source === "jshint") {
-
-        // leave ruleName blank
-    } else {
-
-        // remove 'jshint:' in the beginning
-        ruleName = diagnostic.source.replace(/^jshint:/u, "");
-    }
+    // see https://github.com/codemirror/lang-javascript/blob/749ed7d353caab74996f3ad98c9c963a0ac646a7/src/eslint.ts#L51
+    const ruleName = diagnostic.source.replace(/^jshint:?/u, "");
 
     root.render(
         <React.StrictMode>

--- a/src/playground/utils/codemirror-linter-extension.js
+++ b/src/playground/utils/codemirror-linter-extension.js
@@ -5,7 +5,7 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 import { Decoration, EditorView, ViewPlugin, logException, WidgetType } from "@codemirror/view";
 import { StateEffect, StateField, Facet } from "@codemirror/state";
 import { hoverTooltip } from "@codemirror/tooltip";
@@ -271,14 +271,16 @@ function assignKeys(actions) {
 
 function renderDiagnostic(view, diagnostic) {
     const element = document.createElement("div");
+    const root = ReactDOM.createRoot(element);
 
-    ReactDOM.render(
-        <Popup
-            message={diagnostic.message}
-            onFix={diagnostic.actions && (() => diagnostic.actions[0].apply(view, diagnostic.from, diagnostic.to))}
-            ruleName={diagnostic.source.replace("jshint:", "")}
-        />,
-        element
+    root.render(
+        <React.StrictMode>
+            <Popup
+                message={diagnostic.message}
+                onFix={diagnostic.actions && (() => diagnostic.actions[0].apply(view, diagnostic.from, diagnostic.to))}
+                ruleName={diagnostic.source.replace("jshint:", "").replace("jshint", "")}
+            />
+        </React.StrictMode>
     );
     return element;
 }


### PR DESCRIPTION
Hi, just notice there's this `jshint` thing which links to `https://eslint.org/docs/rules/jshint`.

![CleanShot 2022-07-05 at 23 21 36@2x](https://user-images.githubusercontent.com/1091472/177362322-d7701d01-e362-42d4-a683-af0de2333344.png)

Here's the code I used to test:

```
module.exports = (env, argv) => ({

  if (argv.mode === 'development') {
    config.devtool = 'source-map';
  }

  if (argv.mode === 'production') {
    //...
  }

  return config;
});
```

Not sure it's a typo in the original source code or there's another edge case to fix.

Besides, since React 18 is used in this project, I've update the React related syntax to the latest version.